### PR TITLE
Fixed bug in buffer refill block

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -144,6 +144,7 @@ int main() {
       memmove(inbuf, data, data_size);
       data = inbuf;
       len = fread(data + data_size, 1, AUDIO_INBUF_SIZE - data_size, f);
+      data_size += len;
       if (len < 0) {
         data_size += len;
       }


### PR DESCRIPTION
The amount of data available in the buffer for processing wasn't being incremented after the fread, which meant that eventually the loop thought the data was exhausted, when it wasn't